### PR TITLE
Use new endpoint for Plex v >=1.15

### DIFF
--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-URLBASIC="https://plex.tv/api/downloads/1.json"
-URLPLEXPASS="https://plex.tv/api/downloads/1.json?channel=plexpass"
+URLBASIC="https://plex.tv/api/downloads/5.json"
+URLPLEXPASS="https://plex.tv/api/downloads/5.json?channel=plexpass"
 DOWNLOADPATH="/tmp"
 LOGPATH="/tmp"
 LOGFILE="PMS_Updater.log"


### PR DESCRIPTION
It should be noted that this endpoint does not seem to be returning any data yet:

```
$ curl -i https://plex.tv/api/downloads/5.json
HTTP/2 200
date: Thu, 14 Feb 2019 16:56:33 GMT
content-type: application/json; charset=utf-8
x-ua-compatible: chrome=1
cache-control: no-cache
vary: Origin
x-request-id: a62d5e59-c4e9-4398-bedc-42aa28745b7e
x-runtime: 0.007216
strict-transport-security: max-age=0
referrer-policy: origin-when-cross-origin
x-content-type-options: nosniff
x-frame-options: DENY
x-xss-protection: 1; mode=block

{"computer":{},"nas":{}}%
```

Closes #29