### PR TITLE
Modifications for updating non-PlexPass versions

### DIFF
--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -8,6 +8,7 @@ LOGFILE="PMS_Updater.log"
 PMSPARENTPATH="/usr/local/share"
 PMSLIVEFOLDER="plexmediaserver-plexpass"
 PMSBAKFOLDER="plexmediaserver-plexpass.bak"
+SERVICENAME="plexmediaserver-plexpass"
 CERTFILE="/usr/local/share/certs/ca-root-nss.crt"
 AUTOUPDATE=0
 FORCEUPDATE=0
@@ -191,7 +192,7 @@ applyUpdate()
     rm -rf $PMSPARENTPATH/$PMSBAKFOLDER 2>&1 | LogMsg
     echo Done. | LogMsg -f
     echo Stopping Plex Media Server .....| LogMsg -n
-    service plexmediaserver_plexpass stop 2>&1
+    service $SERVICENAME stop 2>&1
     echo Done. | LogMsg -f
     echo Moving current Plex Media Server to backup location .....| LogMsg -n
     mv $PMSPARENTPATH/$PMSLIVEFOLDER/ $PMSPARENTPATH/$PMSBAKFOLDER/ 2>&1 | LogMsg
@@ -209,7 +210,7 @@ applyUpdate()
     ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/Plex\ Media\ Server $PMSPARENTPATH/$PMSLIVEFOLDER/Plex_Media_Server 2>&1 | LogMsg
     ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/libpython2.7.so.1 $PMSPARENTPATH/$PMSLIVEFOLDER/libpython2.7.so 2>&1 | LogMsg
     echo Starting Plex Media Server .....| LogMsg -n
-    service plexmediaserver_plexpass start
+    service $SERVICENAME start
     echo Done. | LogMsg -f
 }
 
@@ -229,6 +230,13 @@ do
          ?) usage; exit 1 ;;
      esac
 done
+
+# Change variables depending on PLEXPASS option.
+if [ $PLEXPASS = 0 ]; then {
+	PMSLIVEFOLDER="plexmediaserver"
+	PMSBAKFOLDER="plexmediaserver.bak"
+	SERVICENAME="plexmediaserver"
+} fi
 
 # Get the current version
 CURRENTVER=`export LD_LIBRARY_PATH=$PMSPARENTPATH/$PMSLIVEFOLDER; $PMSPARENTPATH/$PMSLIVEFOLDER/Plex\ Media\ Server --version`


### PR DESCRIPTION
The earlier version wasn't updating non-PlexPass version - service start/stop were erroring out. Added in the SERVICENAME variable, and changed the PMS(LIVE/BAK)FOLDERS depending on whether PLEXPASS or not.