### PR TITLE
Fix PMS_Updater for Newer Versions of Plex Plugin

### DIFF
--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -10,19 +10,19 @@ LOGGING=1
 # Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
 
 if [ -f /Plex\ Media\ Server/Preferences.xml ]; then
-   echo "Preferences found in /";
+   if [ $VERBOSE = 1 ]; echo "Preferences found in /Plex Media Server"; fi
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
 elif [ -f /usr/local/plex/Plex\ Media\ Server/Preferences.xml ]; then
-   echo "Preferences found in /usr/local/plexdata/"
+   if [ $VERBOSE = 1 ]; then echo "Preferences found in /usr/local/plexdata/"; fi
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plex/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
 elif [ -f /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml ]; then
-   echo "Preferences found in /usr/local/plexdata-plexpass/"
+   if [ $VERBOSE = 1 ]; then echo "Preferences found in /usr/local/plexdata-plexpass/"; fi
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
    
 else
-   echo "Preferences.xml not found. You won't be able to update to the PlexPass version, but it will update to latest non-PlexPass version."
+   echo "Preferences.xml not found. This will likely prevent the script from downloading the latest version of Plex. You can still manually download Plex and run PMS_Updater.sh with the -l flag."
 fi
 
 BASEURL="https://plex.tv/api/downloads/5.json"

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -10,7 +10,7 @@ LOGGING=1
 # Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
 
 if [ -f /Plex\ Media\ Server/Preferences.xml ]; then
-   if [ $VERBOSE = 1 ]; echo then "Preferences found in /Plex Media Server"; fi
+   if [ $VERBOSE = 1 ]; then echo "Preferences found in /Plex Media Server"; fi
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
 elif [ -f /usr/local/plex/Plex\ Media\ Server/Preferences.xml ]; then

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -9,15 +9,18 @@ LOGGING=1
 # In newer versions of the iocage the 'Plex Media Server' has moved from / to either /usr/local/plexdata or /usr/local/plexdata-plexpass/.
 # Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
 
-if test -f "/Plex\ Media\ Server/Preferences.xml"; then
-   echo "Preferences found in /"
+if [ -f "/Plex\ Media\ Server/Preferences.xml" ]
+   then
+   echo "Preferences found in /";
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
-elif test -f "/usr/local/plex/Plex\ Media\ Server/Preferences.xml"; then
+elif [ -f "/usr/local/plex/Plex\ Media\ Server/Preferences.xml" ]
+   then
    echo "Preferences found in /usr/local/plexdata/"
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plex/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
-elif test -f "/usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml"; then
+elif [ -f "/usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml" ]
+   then
    echo "Preferences found in /usr/local/plexdata-plexpass/"
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
    

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -10,15 +10,12 @@ LOGGING=1
 # Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
 
 if [ -f /Plex\ Media\ Server/Preferences.xml ]; then
-   if [ $VERBOSE = 1 ]; then echo "Preferences found in /Plex Media Server"; fi
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
 elif [ -f /usr/local/plex/Plex\ Media\ Server/Preferences.xml ]; then
-   if [ $VERBOSE = 1 ]; then echo "Preferences found in /usr/local/plexdata/"; fi
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plex/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
 elif [ -f /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml ]; then
-   if [ $VERBOSE = 1 ]; then echo "Preferences found in /usr/local/plexdata-plexpass/"; fi
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
    
 else

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -10,7 +10,7 @@ LOGGING=1
 # Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
 
 if [ -f /Plex\ Media\ Server/Preferences.xml ]; then
-   if [ $VERBOSE = 1 ]; echo "Preferences found in /Plex Media Server"; fi
+   if [ $VERBOSE = 1 ]; echo then "Preferences found in /Plex Media Server"; fi
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
 elif [ -f /usr/local/plex/Plex\ Media\ Server/Preferences.xml ]; then

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -9,18 +9,15 @@ LOGGING=1
 # In newer versions of the iocage the 'Plex Media Server' has moved from / to either /usr/local/plexdata or /usr/local/plexdata-plexpass/.
 # Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
 
-if [ -f "/Plex\ Media\ Server/Preferences.xml" ]
-   then
+if [ -f "/Plex\ Media\ Server/Preferences.xml" ]; then
    echo "Preferences found in /";
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
-elif [ -f "/usr/local/plex/Plex\ Media\ Server/Preferences.xml" ]
-   then
+elif [ -f "/usr/local/plex/Plex\ Media\ Server/Preferences.xml" ]; then
    echo "Preferences found in /usr/local/plexdata/"
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plex/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
-elif [ -f "/usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml" ]
-   then
+elif [ -f "/usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml" ]; then
    echo "Preferences found in /usr/local/plexdata-plexpass/"
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
    

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -9,15 +9,15 @@ LOGGING=1
 # In newer versions of the iocage the 'Plex Media Server' has moved from / to either /usr/local/plexdata or /usr/local/plexdata-plexpass/.
 # Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
 
-if [ -f "/Plex\ Media\ Server/Preferences.xml" ]; then
+if [ -f /Plex\ Media\ Server/Preferences.xml ]; then
    echo "Preferences found in /";
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
-elif [ -f "/usr/local/plex/Plex\ Media\ Server/Preferences.xml" ]; then
+elif [ -f /usr/local/plex/Plex\ Media\ Server/Preferences.xml ]; then
    echo "Preferences found in /usr/local/plexdata/"
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plex/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
 
-elif [ -f "/usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml" ]; then
+elif [ -f /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml ]; then
    echo "Preferences found in /usr/local/plexdata-plexpass/"
    PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
    

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -6,7 +6,25 @@ VERBOSE=1
 REMOVE=1
 LOGGING=1
 
-PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
+# In newer versions of the iocage the 'Plex Media Server' has moved from / to either /usr/local/plexdata or /usr/local/plexdata-plexpass/.
+# Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
+
+if test -f "/Plex\ Media\ Server/Preferences.xml"; then
+   echo "Preferences found in /"
+   PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
+
+elif test -f "/usr/local/plex/Plex\ Media\ Server/Preferences.xml"; then
+   echo "Preferences found in /usr/local/plexdata/"
+   PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plex/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
+
+elif test -f "/usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml"; then
+   echo "Preferences found in /usr/local/plexdata-plexpass/"
+   PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
+   
+else
+   echo "Preferences.xml not found. You won't be able to update to the PlexPass version, but it will update to latest non-PlexPass version."
+fi
+
 BASEURL="https://plex.tv/api/downloads/5.json"
 TOKENURL="$BASEURL?channel=plexpass&X-Plex-Token=$PLEXTOKEN"
 DOWNLOADPATH="/tmp"


### PR DESCRIPTION
In newer installs of the Plex Plugin, rather than putting the Plex Media Server folder under /, it's either under /usr/local/plexdata/ or /usr/local/plexdata-plexpass/. This update checks all three locations for the preferences file so that it can correctly grab the token in these situations.