### PR TITLE
Fixed download by working around environment issues

### DIFF
--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -180,6 +180,7 @@ applyUpdate()
     } fi
     ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/Plex\ Media\ Server $PMSPARENTPATH/$PMSLIVEFOLDER/Plex_Media_Server 2>&1 | LogMsg
     ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/lib/libpython2.7.so.1 $PMSPARENTPATH/$PMSLIVEFOLDER/libpython2.7.so 2>&1 | LogMsg
+    ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/Resources/Python/python27.zip $PMSPARENTPATH/$PMSLIVEFOLDER/ 2>&1 | LogMsg
     echo Starting Plex Media Server .....| LogMsg -n
     service $SERVICENAME start
     echo Done. | LogMsg -f
@@ -213,6 +214,11 @@ if [ -d "${PMSPARENTPATH}/plexmediaserver-plexpass" ]; then {
 
 
 export PYTHONHOME="$PMSPARENTPATH/$PMSLIVEFOLDER/Resources/Python"
+#fix/hack to recent python change in plex
+if [ -h "${PMSPARENTPATH}/${PMSLIVEFOLDER}/python27.zip" ]; then {
+} else {
+ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/Resources/Python/python27.zip $PMSPARENTPATH/$PMSLIVEFOLDER/ 2>&1 | LogMsg
+} fi
 
 # Get the current version
 CURRENTVER=`export LD_LIBRARY_PATH=$PMSPARENTPATH/$PMSLIVEFOLDER/lib; $PMSPARENTPATH/$PMSLIVEFOLDER/Plex\ Media\ Server --version`

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -6,7 +6,13 @@ VERBOSE=1
 REMOVE=1
 LOGGING=1
 
-PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' /Plex\ Media\ Server/Preferences.xml | sed 's/\".*//')"
+#check if we're in pms plugin, or standard jail
+if [ -e "/Plex Media Server/Preferences.xml" ]; then {
+        PREFS="/Plex Media Server/Preferences.xml"
+} else {
+        PREFS="/usr/local/plexdata-plexpass/Plex Media Server/Preferences.xml"
+} fi
+PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' "${PREFS}" | sed 's/\".*//')"
 BASEURL="https://plex.tv/api/downloads/5.json"
 TOKENURL="$BASEURL?channel=plexpass&X-Plex-Token=$PLEXTOKEN"
 DOWNLOADPATH="/tmp"

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -6,12 +6,20 @@ VERBOSE=1
 REMOVE=1
 LOGGING=1
 
-#check if we're in pms plugin, or standard jail
-if [ -e "/Plex Media Server/Preferences.xml" ]; then {
+# Try to find the Preferences.xml in all possible folders to fetch the token for downloads of PlexPass versions.
+
+if [ -f /Plex\ Media\ Server/Preferences.xml ]; then
         PREFS="/Plex Media Server/Preferences.xml"
-} else {
+elif
+        [ -f /usr/local/plex/Plex\ Media\ Server/Preferences.xml ]; then
+        PREFS="/usr/local/plex/Plex Media Server/Preferences.xml"
+elif
+        [ -f /usr/local/plexdata-plexpass/Plex\ Media\ Server/Preferences.xml ]; then
         PREFS="/usr/local/plexdata-plexpass/Plex Media Server/Preferences.xml"
-} fi
+else
+   echo "Preferences.xml not found. This will likely prevent the script from downloading the latest version of Plex. You can still manually download Plex and run PMS_UpdaUpdater.sh with the -l flag."
+fi
+
 PLEXTOKEN="$(sed -n 's/.*PlexOnlineToken="//p' "${PREFS}" | sed 's/\".*//')"
 BASEURL="https://plex.tv/api/downloads/5.json"
 TOKENURL="$BASEURL?channel=plexpass&X-Plex-Token=$PLEXTOKEN"

--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -179,8 +179,6 @@ applyUpdate()
         echo Done. | LogMsg -f
     } fi
     ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/Plex\ Media\ Server $PMSPARENTPATH/$PMSLIVEFOLDER/Plex_Media_Server 2>&1 | LogMsg
-    ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/lib/libpython2.7.so.1 $PMSPARENTPATH/$PMSLIVEFOLDER/libpython2.7.so 2>&1 | LogMsg
-    ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/Resources/Python/python27.zip $PMSPARENTPATH/$PMSLIVEFOLDER/ 2>&1 | LogMsg
     echo Starting Plex Media Server .....| LogMsg -n
     service $SERVICENAME start
     echo Done. | LogMsg -f
@@ -214,11 +212,7 @@ if [ -d "${PMSPARENTPATH}/plexmediaserver-plexpass" ]; then {
 
 
 export PYTHONHOME="$PMSPARENTPATH/$PMSLIVEFOLDER/Resources/Python"
-#fix/hack to recent python change in plex
-if [ -h "${PMSPARENTPATH}/${PMSLIVEFOLDER}/python27.zip" ]; then {
-} else {
-ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/Resources/Python/python27.zip $PMSPARENTPATH/$PMSLIVEFOLDER/ 2>&1 | LogMsg
-} fi
+export PYTHONPATH="$PYTHONHOME/python27.zip"
 
 # Get the current version
 CURRENTVER=`export LD_LIBRARY_PATH=$PMSPARENTPATH/$PMSLIVEFOLDER/lib; $PMSPARENTPATH/$PMSLIVEFOLDER/Plex\ Media\ Server --version`


### PR DESCRIPTION
Had to work around plex python environment not reading my variables, used ln -s to move python27.zip file to python binary's current directory, seems to work great no issues in testing.